### PR TITLE
Add ActivityView wrapper and fix Swift 6 concurrency capture

### DIFF
--- a/Features/Import/ImportViewModel.swift
+++ b/Features/Import/ImportViewModel.swift
@@ -100,10 +100,10 @@ final class ImportViewModel: ObservableObject {
 
         let toProcess = assets
         let total = Double(max(toProcess.count, 1))
-        var done = 0.0
 
-        processingTask = Task { [weak self] in
+        processingTask = Task { [weak self, toProcess, total] in
             guard let self = self else { return }
+            var done = 0.0
             for a in toProcess {
                 if Task.isCancelled || self.isCancelled { break }
 

--- a/Shared/UI/ActivityView.swift
+++ b/Shared/UI/ActivityView.swift
@@ -1,12 +1,21 @@
 import SwiftUI
 import UIKit
 
-struct ActivityView: UIViewControllerRepresentable {
-    let activityItems: [Any]
+/// A simple wrapper around ``UIActivityViewController`` that can be used from
+/// SwiftUI.  It presents the standard iOS share sheet with the provided items.
+public struct ActivityView: UIViewControllerRepresentable {
+    /// Items to share.
+    public let activityItems: [Any]
 
-    func makeUIViewController(context: Context) -> UIActivityViewController {
+    /// Creates a new activity view with the given items.
+    /// - Parameter activityItems: Objects to pass to ``UIActivityViewController``.
+    public init(activityItems: [Any]) {
+        self.activityItems = activityItems
+    }
+
+    public func makeUIViewController(context: Context) -> UIActivityViewController {
         UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
     }
 
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+    public func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }


### PR DESCRIPTION
## Summary
- expose ActivityView for SwiftUI share sheets
- fix ImportViewModel progress tracking to avoid Swift 6 concurrent capture error

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689f54facf7883309b0251893e3ffe37