### PR TITLE
Add ability to clear and delete results

### DIFF
--- a/Features/Results/ResultsViewModel.swift
+++ b/Features/Results/ResultsViewModel.swift
@@ -34,4 +34,15 @@ final class ResultsViewModel: ObservableObject {
             return nil
         }
     }
+
+    func delete(at offsets: IndexSet) {
+        let ids = offsets.map { cards[$0].assetId }
+        store.delete(ids)
+        cards.remove(atOffsets: offsets)
+    }
+
+    func clearAll() {
+        store.deleteAll()
+        cards.removeAll()
+    }
 }

--- a/Persistence/JSONStore.swift
+++ b/Persistence/JSONStore.swift
@@ -50,6 +50,12 @@ final class JSONStore {
         save()
     }
 
+    func deleteAll() {
+        load()
+        cache.removeAll()
+        save()
+    }
+
     private func save() {
         if let data = try? JSONEncoder().encode(cache) {
             try? data.write(to: url, options: .atomic)


### PR DESCRIPTION
## Summary
- allow deleting individual result cards with swipe
- add toolbar button to clear all results with confirmation
- add store helpers for clearing persisted results

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project ScreenShotAutoRun.xcodeproj -scheme ScreenShotAutoRun -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_689f9b58af1883309b2f3167465de9db