### PR TITLE
Add camera scanning and result category filtering

### DIFF
--- a/Persistence/JSONStore.swift
+++ b/Persistence/JSONStore.swift
@@ -6,6 +6,28 @@ struct ProcessedAsset: Codable, Identifiable {
     let createdAt: Date
     let ocrText: String
     let ids: [DetectedIDDTO]
+    let category: String
+
+    init(localId: String, createdAt: Date, ocrText: String, ids: [DetectedIDDTO], category: String = "Unknown") {
+        self.localId = localId
+        self.createdAt = createdAt
+        self.ocrText = ocrText
+        self.ids = ids
+        self.category = category
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case localId, createdAt, ocrText, ids, category
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.localId = try container.decode(String.self, forKey: .localId)
+        self.createdAt = try container.decode(Date.self, forKey: .createdAt)
+        self.ocrText = try container.decode(String.self, forKey: .ocrText)
+        self.ids = try container.decode([DetectedIDDTO].self, forKey: .ids)
+        self.category = try container.decodeIfPresent(String.self, forKey: .category) ?? "Unknown"
+    }
 }
 
 struct DetectedIDDTO: Codable, Hashable {


### PR DESCRIPTION
## Summary
- add camera button on scan page to capture an image, process it, and preview detected data
- track album or camera category for scans and persist with results
- filter results by category with a segmented picker and include category in CSV export

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a58cc3177883308a917fde4ed9266b